### PR TITLE
Restrict DownloadLinks to a specific user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .phpunit.result.cache
 .idea
 .php_cs.cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ $link = DownloadLink::disk('public')->filePath('uploads/test.txt')->allowIp('127
 $link = DownloadLink::disk('public')->filePath('uploads/test.txt')->allowIp(['127.0.0.1', '127.0.0.2', '127.0.0.3'])->generate();
 ```
 
+You may assign the link to one or more users (Only those users can use the link):
+
+```php
+$userId = 10;
+$link = DownloadLink::disk('public')->filePath('uploads/test.txt')->for($userId)->generate();
+
+$userIds = [10, 20, 30];
+$link = DownloadLink::disk('public')->filePath('uploads/test.txt')->for($userIds)->generate();
+```
+
 The default download route in the config file is "download", so if your domain is "example.com", then you should use this link to download:
 
 ```

--- a/database/migrations/create_download_link_users_table.php.stub
+++ b/database/migrations/create_download_link_users_table.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDownloadLinkUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('download_link_users', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('download_link_id')->constrained()->onDelete('cascade');
+            $table->bigInteger('user_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('download_link_users');
+    }
+}

--- a/database/migrations/create_download_links_table.php.stub
+++ b/database/migrations/create_download_links_table.php.stub
@@ -16,7 +16,6 @@ class CreateDownloadLinksTable extends Migration
             $table->string('file_name');
             $table->boolean('auth_only');
             $table->boolean('guest_only');
-            $table->foreignId('user_id')->nullable()->constrained()->onDelete('cascade');
             $table->dateTime('expire_time')->nullable();
             $table->timestamps();
         });
@@ -32,6 +31,6 @@ class CreateDownloadLinksTable extends Migration
     public function down()
     {
         Schema::dropIfExists('download_links');
-        Schema::dropIfExists('download_link_ip_address');
+        Schema::dropIfExists('download_link_ip_addresses');
     }
 }

--- a/database/migrations/create_download_links_table.php.stub
+++ b/database/migrations/create_download_links_table.php.stub
@@ -16,6 +16,7 @@ class CreateDownloadLinksTable extends Migration
             $table->string('file_name');
             $table->boolean('auth_only');
             $table->boolean('guest_only');
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('cascade');
             $table->dateTime('expire_time')->nullable();
             $table->timestamps();
         });

--- a/src/DownloadLinkGenerator.php
+++ b/src/DownloadLinkGenerator.php
@@ -4,6 +4,7 @@ namespace Armancodes\DownloadLink;
 
 use Armancodes\DownloadLink\Models\DownloadLink;
 use Armancodes\DownloadLink\Models\DownloadLinkIpAddress;
+use Armancodes\DownloadLink\Models\DownloadLinkUser;
 use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -107,6 +108,8 @@ class DownloadLinkGenerator
 
         $this->attachIpToLink($downloadLink->id);
 
+        $this->attachUserToLink($downloadLink->id);
+
         DB::commit();
 
         return $downloadLink->link;
@@ -135,6 +138,15 @@ class DownloadLinkGenerator
         }
     }
 
+    private function attachUserToLink(int $downloadLinkId): void
+    {
+        $users = collect($this->userId);
+
+        $users->each(function ($userId, $key) use ($downloadLinkId) {
+            $this->createUserForDownloadLink($userId, $downloadLinkId);
+        });
+    }
+
     private function createIpAddressForDownloadLink($ip, int $downloadLinkId, $allowed = false)
     {
         if (! filter_var($ip, FILTER_VALIDATE_IP)) {
@@ -147,6 +159,14 @@ class DownloadLinkGenerator
             'download_link_id' => $downloadLinkId,
             'ip_address' => $ip,
             'allowed' => $allowed,
+        ]);
+    }
+
+    private function createUserForDownloadLink(int $userId, int $downloadLinkId)
+    {
+        DownloadLinkUser::create([
+            'download_link_id' => $downloadLinkId,
+            'user_id' => $userId,
         ]);
     }
 

--- a/src/DownloadLinkGenerator.php
+++ b/src/DownloadLinkGenerator.php
@@ -200,7 +200,6 @@ class DownloadLinkGenerator
             'auth_only' => $this->authOnly,
             'guest_only' => $this->guestOnly,
             'expire_time' => $expireTime,
-            'user_id' => $this->userId,
         ]);
     }
 

--- a/src/DownloadLinkGenerator.php
+++ b/src/DownloadLinkGenerator.php
@@ -20,6 +20,7 @@ class DownloadLinkGenerator
     private $expireTime;
     private $limitIp;
     private $allowIp;
+    private $userId;
 
     const DOWNLOAD_LINK_NUMBER_OF_CHARACTERS = 64;
 
@@ -83,6 +84,13 @@ class DownloadLinkGenerator
     public function allowIp($allowIp)
     {
         $this->allowIp = $allowIp;
+
+        return $this;
+    }
+
+    public function for($userId)
+    {
+        $this->userId = $userId;
 
         return $this;
     }
@@ -172,6 +180,7 @@ class DownloadLinkGenerator
             'auth_only' => $this->authOnly,
             'guest_only' => $this->guestOnly,
             'expire_time' => $expireTime,
+            'user_id' => $this->userId,
         ]);
     }
 

--- a/src/DownloadLinkServiceProvider.php
+++ b/src/DownloadLinkServiceProvider.php
@@ -18,11 +18,17 @@ class DownloadLinkServiceProvider extends ServiceProvider
                 __DIR__ . '/../resources/views' => base_path('resources/views/vendor/download-link'),
             ], 'views');
 
-            $migrationFileName = 'create_download_links_table.php';
-            if (! $this->migrationFileExists($migrationFileName)) {
-                $this->publishes([
-                    __DIR__ . "/../database/migrations/{$migrationFileName}.stub" => database_path('migrations/' . date('Y_m_d_His', time()) . '_' . $migrationFileName),
-                ], 'migrations');
+            $migrationFileNames = [
+                'create_download_links_table.php',
+                'create_download_link_users.php',
+            ];
+
+            foreach ($migrationFileNames as $migrationFileName) {
+                if (! $this->migrationFileExists($migrationFileName)) {
+                    $this->publishes([
+                        __DIR__ . "/../database/migrations/{$migrationFileName}.stub" => database_path('migrations/' . date('Y_m_d_His', time()) . '_' . $migrationFileName),
+                    ], 'migrations');
+                }
             }
 
             $this->commands([

--- a/src/Http/Controllers/DownloadLinkController.php
+++ b/src/Http/Controllers/DownloadLinkController.php
@@ -4,6 +4,7 @@ namespace Armancodes\DownloadLink\Http\Controllers;
 
 use Armancodes\DownloadLink\Models\DownloadLink;
 use Armancodes\DownloadLink\Models\DownloadLinkIpAddress;
+use Armancodes\DownloadLink\Models\DownloadLinkUser;
 use Illuminate\Support\Facades\Storage;
 
 class DownloadLinkController
@@ -14,9 +15,9 @@ class DownloadLinkController
 
         $this->fileExists($downloadLink);
 
-        $this->isAuthorized($downloadLink);
-
         $this->isAuthenticated($downloadLink);
+
+        $this->isAuthorized($downloadLink);
 
         $this->isGuest($downloadLink);
 
@@ -34,11 +35,13 @@ class DownloadLinkController
 
     private function isAuthorized($downloadLink)
     {
-        if ($user_id = $downloadLink->user_id) {
-          abort_unless(auth()->check() && auth()->id() == $user_id, 401);
+        $downloadLinkUsers = DownloadLinkUser::where('download_link_id', $downloadLink->id)->get();
+
+        if ($downloadLinkUsers->isEmpty()) {
+            return;
         }
 
-        return true;
+        abort_if($downloadLinkUsers->where('user_id', auth()->id())->isEmpty(), 401);
     }
 
     private function isAuthenticated($downloadLink)

--- a/src/Http/Controllers/DownloadLinkController.php
+++ b/src/Http/Controllers/DownloadLinkController.php
@@ -14,6 +14,8 @@ class DownloadLinkController
 
         $this->fileExists($downloadLink);
 
+        $this->isAuthorized($downloadLink);
+
         $this->isAuthenticated($downloadLink);
 
         $this->isGuest($downloadLink);
@@ -28,6 +30,15 @@ class DownloadLinkController
     private function fileExists($downloadLink)
     {
         abort_unless(Storage::disk($downloadLink->disk)->exists($downloadLink->file_path), 404, 'File not found!');
+    }
+
+    private function isAuthorized($downloadLink)
+    {
+        if ($user_id = $downloadLink->user_id) {
+          abort_unless(auth()->check() && auth()->id() == $user_id, 401);
+        }
+
+        return true;
     }
 
     private function isAuthenticated($downloadLink)

--- a/src/Models/DownloadLinkUser.php
+++ b/src/Models/DownloadLinkUser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Armancodes\DownloadLink\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DownloadLinkUser extends Model
+{
+    protected $guarded = ['id'];
+
+    protected $table = "download_link_users";
+
+    public $timestamps = false;
+
+    public function downloadLink()
+    {
+        return $this->belongsTo(DownloadLink::class);
+    }
+}

--- a/tests/Http/Controllers/DownloadLinkControllerTest.php
+++ b/tests/Http/Controllers/DownloadLinkControllerTest.php
@@ -83,4 +83,30 @@ class DownloadLinkControllerTest extends TestCase
 
         $this->get(route('download-link.download-route', $link))->assertStatus(403);
     }
+
+    /** @test */
+    public function aborts_401_if_user_is_not_authorized()
+    {
+        Storage::fake('public')->put('example.txt', 'This is a test file');
+
+        $user = factory(User::class)->create();
+
+        auth()->login($user);
+
+        $userId = $user->id + rand(10, 100); // This user does not exist
+
+        $link = DownloadLinkGenerator::disk('public')->filePath('example.txt')->for($userId)->generate();
+
+        $this->get(route('download-link.download-route', $link))->assertStatus(401);
+
+        $userIds = [
+            10,
+            20,
+            30,
+        ];
+
+        $link = DownloadLinkGenerator::disk('public')->filePath('example.txt')->for($userIds)->generate();
+
+        $this->get(route('download-link.download-route', $link))->assertStatus(401);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,8 +31,10 @@ class TestCase extends Orchestra
         ]);
 
         include_once __DIR__.'/../database/migrations/create_download_links_table.php.stub';
+        include_once __DIR__.'/../database/migrations/create_download_link_users_table.php.stub';
         include_once __DIR__.'/../tests/database/migrations/create_users_table.php.stub';
         (new \CreateDownloadLinksTable())->up();
+        (new \CreateDownloadLinkUsersTable())->up();
         (new \CreateUsersTable())->up();
     }
 }


### PR DESCRIPTION
This PR adds functionality to create a DownloadLink for a specific user.

### Usage

When creating a DownloadLink you can chain a `->for($userId)` to assign the link to a specific user:
```php
$link = DownloadLinkGenerator::disk('local')->filePath('files/lesson 1.mp4')->for(auth()->id())->generate();
```

Now only this user will be able to access the download.

Thanks for the package! 😃
